### PR TITLE
Fix Error on No Editable pane

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -41,7 +41,7 @@ module.exports =
   autosavePaneItem: (paneItem) ->
     return false if @isExcludeScope(paneItem?.getGrammar?()?.scopeName)
     return false unless @isIncludeOnlyRepositoryPath(paneItem?.getURI?())
-    return false unless paneItem?.getPath()? and fs.isFileSync(paneItem.getPath())
+    return false unless paneItem?.getPath?()? and fs.isFileSync(paneItem.getPath())
     return true
 
   isExcludeScope: (scopeName) ->


### PR DESCRIPTION
[Enter steps to reproduce below:]
1. Active autosave-plus on setting
2. Open Setting pane
3. Focus out from setting pane

**Atom Version**: 0.207.0
**System**: Mac OS X 10.10.3
**Thrown From**: [autosave-plus](https://github.com/aki77/atom-autosave-plus) package, v0.5.0
### Stack Trace

Uncaught TypeError: undefined is not a function

```
At /Users/mat_aki/.atom/packages/autosave-plus/lib/main.coffee:44

TypeError: undefined is not a function
  at Object.module.exports.autosavePaneItem (/Users/mat_aki/.atom/packages/autosave-plus/lib/main.coffee:44:25)
  at Object.<anonymous> (/Users/mat_aki/.atom/packages/autosave-plus/lib/main.coffee:36:8)
  at Object.object.(anonymous function) [as autosavePaneItem] (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/node_modules/underscore-plus/lib/underscore-plus.js:76:20)
  at Object.module.exports.autosaveAllPaneItems (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/node_modules/autosave/lib/autosave.js:64:28)
  at /opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app.asar/node_modules/autosave/lib/autosave.js:25:26

```
### Commands

```
  4x -0:56.2.0 core:backspace (atom-text-editor.editor.mini.is-focused)
     -0:12.1.0 core:close (ul.list-inline.tab-bar.inset-panel)
```
### Config

``` json
{
  "core": {
    "themes": [
      "atom-dark-ui",
      "atom-dark-syntax"
    ],
    "disabledPackages": [
      "goto",
      "symbols-view",
      "linter-rubocop",
      "linter-haml",
      "term2"
    ]
  },
  "autosave-plus": {
    "debouncePeriod": 1000
  }
}
```
### Installed Packages

``` coffee
# User
atom-ctags, v4.1.2
autocomplete-emojis, v2.2.2
autocomplete-paths, v1.0.2
autocomplete-ruby, v0.1.0
autosave-plus, v0.5.0
color-picker, v2.0.4
ctags-status, v1.3.1
file-icons, v1.5.7
file-type-icons, v0.6.0
git-log, v0.4.1
git-tab-status, v1.9.2
highlight-selected, v0.9.3
japanese-wrap, v0.2.10
language-SCSS, v0.4.0
language-diff, v0.3.0
language-haml, v0.21.0
line-diff-details, v1.1.1
linter, v0.12.6
linter-jshint, v0.1.6
linter-ruby, v0.1.6
minimap, v4.9.4
minimap-autohide, v0.10.0
minimap-color-highlight, v4.1.4
minimap-find-and-replace, v4.2.0
minimap-git-diff, v4.1.3
project-manager, v1.15.10
project-palette-finder, v2.4.17
ruby-block, v0.3.3
sass-autocompile, v0.7.0
travis-ci-status, v0.15.0

# Dev
autosave-plus, v0.5.0
language-diff, v0.3.0
```
